### PR TITLE
Updating async to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "should": "11.2.1"
   },
   "dependencies": {
-    "async": "2.3.0",
+    "async": "^2.5.0",
     "bluebird": "^3.5.0",
     "bson-objectid": "1.1.5",
     "stow": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/moonbus/bifrost#readme",
   "devDependencies": {
-    "mocha": "3.2.0",
+    "mocha": "^3.4.2",
     "should": "11.2.1"
   },
   "dependencies": {


### PR DESCRIPTION

Please update [async](https://npmjs.org/package/async) to version 2.5.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

